### PR TITLE
[create] error_print

### DIFF
--- a/philo/error_handling.c
+++ b/philo/error_handling.c
@@ -35,7 +35,7 @@ int	strs_is_digit(char **strs)
 	{
 		if (str_is_digit(strs[i]) == FAILURE)
 		{
-			printf(RED"argv includes invalid character!\n"STOP);
+			error_print("argv includes invalid character!");
 			return (FAILURE);
 		}
 		i++;
@@ -50,12 +50,16 @@ int	check_arg_size(char **argv)
 	|| ft_atoll(argv[3]) <= 0 || INT_MAX < ft_atoll(argv[3]) \
 	|| ft_atoll(argv[4]) <= 0 || INT_MAX < ft_atoll(argv[4]))
 	{
-		printf(RED"0 < argv[1] && argv[1] <= INT_MAX\n" \
+		error_print("0 < argv[1] && argv[1] <= INT_MAX\n" \
 		"0 < argv[2] && argv[2] <= INT_MAX\n" \
 		"0 < argv[3] && argv[3] <= INT_MAX\n" \
-		"0 < argv[4] && argv[4] <= INT_MAX\n" \
-		"0 < argv[5] && argv[5] <= INT_MAX\n"STOP);
+		"0 < argv[4] && argv[4] <= INT_MAX\n");
 		return (FAILURE);
 	}
 	return (SUCCESS);
+}
+
+void	error_print(char *str)
+{
+	printf(RED"%s\n"STOP, str);
 }

--- a/philo/init.c
+++ b/philo/init.c
@@ -18,7 +18,7 @@ int	init_args(t_info *info, int argc, char **argv)
 		return (FAILURE);
 	if (200 <= ft_atoll(argv[1]))
 	{
-		printf(RED"number_of_philosophers should be under 200.\n"STOP);
+		error_print("number_of_philosophers should be under 200.");
 		return (FAILURE);
 	}
 	info->nb_philo = ft_atoll(argv[1]);

--- a/philo/main.c
+++ b/philo/main.c
@@ -14,12 +14,12 @@
 
 int	print_usage(void)
 {
-	printf(RED"[usage]\n" \
+	error_print("[usage]\n" \
 				" [1]:number_of_philosophers\n" \
 				" [2]:time_to_die\n" \
 				" [3]:time_to_eat\n" \
 				" [4]:time_to_sleep\n" \
-				"([5]:number_of_times_each_philosopher_must_eat)\n"STOP);
+				"([5]:number_of_times_each_philosopher_must_eat)");
 	return (FAILURE);
 }
 

--- a/philo/philosophers.h
+++ b/philo/philosophers.h
@@ -75,4 +75,5 @@ int			only_one_philosopher(t_info *info);
 int64_t		ft_atoll(char *str);
 int			check_arg_size(char **argv);
 int			strs_is_digit(char **strs);
+void		error_print(char *str);
 #endif


### PR DESCRIPTION
error_print.cを作成し、RED色でメッセージを出したい箇所をprintf()からerror_print()に置き換えた。
何度も使用していた　`printf(RED%s"メッセージ"STOP)`を関数化することで保守性を意識した実装にできた。

質問：
error_print()はこの実装でよかったのか。より汎用性の高い書き方を知りたい。
（printf()をそのまま使用するのとあまり変わらないと感じてしまった。）

参考文献：https://wa3.i-3-i.info/word15942.html